### PR TITLE
fix HA

### DIFF
--- a/statefun/runtime.go
+++ b/statefun/runtime.go
@@ -684,11 +684,6 @@ func (r *Runtime) singleInstanceFunctionLocksUpdater(ctx context.Context, revisi
 			}
 
 			if r.config.isActiveInstance {
-				if r.afterStartRunning.CompareAndSwap(false, true) {
-					lg.GetLogger().Debugf(ctx, "runtime is active, run afterStartFunctions")
-					r.runAfterStartFunctions(r.gs.phaseOneCtx())
-				}
-
 				for ftName, revID := range revisions {
 					if revID == 0 {
 						tryLock(ftName)
@@ -712,6 +707,11 @@ func (r *Runtime) singleInstanceFunctionLocksUpdater(ctx context.Context, revisi
 				if err := r.startFunctionSubscriptions(ctx, revisions); err != nil {
 					lg.Logf(lg.ErrorLevel, "function subscriptions failed: %v", err)
 				}
+			}
+
+			if r.afterStartRunning.CompareAndSwap(false, true) {
+				lg.GetLogger().Debugf(ctx, "run afterStartFunctions")
+				r.runAfterStartFunctions(r.gs.phaseOneCtx())
 			}
 		}
 	}

--- a/statefun/runtime.go
+++ b/statefun/runtime.go
@@ -605,7 +605,6 @@ func (r *Runtime) singleInstanceFunctionLocksUpdater(ctx context.Context, revisi
 		r.stopFunctionSubscriptions(ctx)
 		if r.afterStartRunning.Load() {
 			r.gs.cancelPhaseOne()
-			r.afterStartRunning.Store(false)
 		}
 		kvConsistencyCheck = nil
 	}
@@ -650,6 +649,7 @@ func (r *Runtime) singleInstanceFunctionLocksUpdater(ctx context.Context, revisi
 							r.config.isActiveInstance = true
 							r.activeInstanceMu.Unlock()
 							r.gs.resetPhaseOneCtx()
+							r.afterStartRunning.Store(false)
 							subscribeRequired = true
 						}
 					default:

--- a/statefun/wal.go
+++ b/statefun/wal.go
@@ -15,6 +15,8 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
+var errTransactionAlreadyApplied = fmt.Errorf("transaction already applied by another runtime")
+
 const (
 	WALOperationsStreamName = "wal_operations"
 	WALCommitsStreamName    = "wal_commits"
@@ -136,6 +138,12 @@ func (dm *Domain) runTransactionCommitter(ctx context.Context, ready chan struct
 			}
 
 			if err := dm.applyTransactionOperations(ctx, txID); err != nil {
+				if errors.Is(err, errTransactionAlreadyApplied) {
+					lg.Logf(lg.DebugLevel, "TransactionCommitter: transaction %s already applied, acking", txID)
+					system.MsgOnErrorReturn(msg.Ack())
+					processedCount++
+					return
+				}
 				lg.Logf(lg.ErrorLevel, "TransactionCommitter: failed to apply transaction %s: %s", txID, err)
 				system.MsgOnErrorReturn(msg.Nak())
 				return
@@ -237,6 +245,10 @@ func (dm *Domain) applyTransactionOperations(ctx context.Context, txID string) e
 
 	sub, err := dm.js.PullSubscribe(opsSubject, consumerName)
 	if err != nil {
+		if errors.Is(err, nats.ErrConsumerDeleted) {
+			lg.Logf(lg.DebugLevel, "Per-tx consumer %s already deleted, transaction applied by another runtime", consumerName)
+			return errTransactionAlreadyApplied
+		}
 		lg.Logf(lg.ErrorLevel, "Failed to create subscription: %s", err)
 		return fmt.Errorf("failed to subscribe to operations: %w", err)
 	}
@@ -257,6 +269,10 @@ func (dm *Domain) applyTransactionOperations(ctx context.Context, txID string) e
 			if errors.Is(err, nats.ErrTimeout) {
 				lg.Logf(lg.TraceLevel, "applyTransactionOperations: finished, processed %d operations for tx_id=%s", totalOps, txID)
 				break
+			}
+			if errors.Is(err, nats.ErrConsumerDeleted) {
+				lg.Logf(lg.DebugLevel, "Per-tx consumer deleted during fetch, transaction applied by another runtime (tx_id=%s)", txID)
+				return errTransactionAlreadyApplied
 			}
 			return fmt.Errorf("failed to fetch operations: %w", err)
 		}


### PR DESCRIPTION
- improves HA behavior by handling nats.ErrConsumerDeleted as “already applied by another runtime” (ACK instead of false NAK/retry), and moves afterStart trigger to the common tick path

- fixes afterStart re-run timing by resetting afterStartRunning on successful passive -> active transition (after KV consistency), not on becomePassive