### PR TITLE
FOL-157-passive-runtime-must-not-generate-new-wal-trx

### DIFF
--- a/statefun/cache/cache.go
+++ b/statefun/cache/cache.go
@@ -295,6 +295,9 @@ type Store struct {
 	transactionsMutex           *sync.Mutex
 	getKeysByPatternFromKVMutex *sync.Mutex
 
+	// walWriteEnabled - true for active instance
+	// only active instances can write to WAL streams
+	walWriteEnabled      atomic.Bool
 	transactionGenerator TransactionGenerator
 
 	//write barrier state
@@ -499,6 +502,9 @@ func NewCacheStore(ctx context.Context, cacheConfig *Config, js nats.JetStreamCo
 
 	cs.ctx, cs.cancel = context.WithCancel(ctx)
 
+	// default - can not publish to WAL
+	cs.walWriteEnabled.Store(false)
+
 	storeUpdatesHandler := func(cs *Store) {
 		system.GlobalPrometrics.GetRoutinesCounter().Started("cache.storeUpdatesHandler")
 		defer system.GlobalPrometrics.GetRoutinesCounter().Stopped("cache.storeUpdatesHandler")
@@ -594,6 +600,11 @@ func NewCacheStore(ctx context.Context, cacheConfig *Config, js nats.JetStreamCo
 
 			if cs.transactionGenerator == nil {
 				le.Debugf(ctx, "WAL is not ready, skip this iteration")
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			if !cs.walWriteEnabled.Load() {
+				le.Debugf(ctx, "WAL writes are disabled, skip this iteration")
 				time.Sleep(100 * time.Millisecond)
 				continue
 			}
@@ -1227,6 +1238,10 @@ type TransactionGenerator interface {
 
 func (cs *Store) SetTransactionGenerator(tg TransactionGenerator) {
 	cs.transactionGenerator = tg
+}
+
+func (cs *Store) SetWALWriteEnabled(enabled bool) {
+	cs.walWriteEnabled.Store(enabled)
 }
 
 // -----------------------------------

--- a/statefun/runtime.go
+++ b/statefun/runtime.go
@@ -259,6 +259,9 @@ func (r *Runtime) Start(ctx context.Context, cacheConfig *cache.Config) error {
 		r.config.isActiveInstance = true
 	}
 
+	// if active - can publish to WAL, passive - can not
+	r.Domain.Cache().SetWALWriteEnabled(r.config.isActiveInstance)
+
 	// Handle single-instance functions.
 	singleInstanceFunctionRevisions := make(map[string]uint64)
 	if err := r.handleSingleInstanceFunctions(r.gs.ctxPhaseThree, singleInstanceFunctionRevisions); err != nil {
@@ -602,6 +605,7 @@ func (r *Runtime) singleInstanceFunctionLocksUpdater(ctx context.Context, revisi
 		r.config.isActiveInstance = false
 		r.config.activeRevID = 0
 		r.activeInstanceMu.Unlock()
+		r.Domain.Cache().SetWALWriteEnabled(false)
 		r.stopFunctionSubscriptions(ctx)
 		if r.afterStartRunning.Load() {
 			r.gs.cancelPhaseOne()
@@ -648,6 +652,7 @@ func (r *Runtime) singleInstanceFunctionLocksUpdater(ctx context.Context, revisi
 							r.activeInstanceMu.Lock()
 							r.config.isActiveInstance = true
 							r.activeInstanceMu.Unlock()
+							r.Domain.Cache().SetWALWriteEnabled(true)
 							r.gs.resetPhaseOneCtx()
 							r.afterStartRunning.Store(false)
 							subscribeRequired = true


### PR DESCRIPTION
on active -> passive transition is to immediately block generation of new WAL commit/ops messages