### PR TITLE
add chunked graph debug export over NATS Core

### DIFF
--- a/embedded/graph/debug/debug.go
+++ b/embedded/graph/debug/debug.go
@@ -11,7 +11,17 @@ const (
 	MAX_ACK_WAIT_MS = 60 * 1000
 )
 
+// RegisterAllFunctionTypes registers all graph debug/import statefun handlers.
+//
+// Chunked export uses a single function type (print.graph) for all three
+// operations: graph traversal, get_chunk, and finish_session. The operation
+// is selected by the export_action payload field. Using one function type
+// guarantees that all operations are served by the same runtime process —
+// the statefun single-instance lock is per function type, so separate types
+// would have independent locks and could land on different processes, making
+// the in-memory ExportSessionStore invisible across runtimes.
 func RegisterAllFunctionTypes(runtime *statefun.Runtime) {
-	statefun.NewFunctionType(runtime, "functions.graph.api.object.debug.print.graph", LLAPIPrintGraph, *statefun.NewFunctionTypeConfig().SetAllowedRequestProviders(sfPlugins.AutoRequestSelect).SetMsgAckWaitMs(MAX_ACK_WAIT_MS))
-	statefun.NewFunctionType(runtime, "functions.graph.api.import", LLAPIImportGraph, *statefun.NewFunctionTypeConfig().SetAllowedRequestProviders(sfPlugins.AutoRequestSelect).SetMsgAckWaitMs(MAX_ACK_WAIT_MS))
+	cfg := *statefun.NewFunctionTypeConfig().SetAllowedRequestProviders(sfPlugins.AutoRequestSelect).SetMsgAckWaitMs(MAX_ACK_WAIT_MS)
+	statefun.NewFunctionType(runtime, "functions.graph.api.object.debug.print.graph", LLAPIPrintGraph, cfg)
+	statefun.NewFunctionType(runtime, "functions.graph.api.import", LLAPIImportGraph, cfg)
 }

--- a/embedded/graph/debug/export_test.go
+++ b/embedded/graph/debug/export_test.go
@@ -1,0 +1,350 @@
+package debug
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/foliagecp/easyjson"
+	"github.com/foliagecp/sdk/embedded/graph/crud"
+	"github.com/foliagecp/sdk/statefun"
+	sfPlugins "github.com/foliagecp/sdk/statefun/plugins"
+	"github.com/foliagecp/sdk/statefun/system"
+	"github.com/foliagecp/sdk/statefun/test"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestMain(m *testing.M) {
+	if system.GlobalPrometrics == nil {
+		system.GlobalPrometrics = system.NewPrometrics("", "127.0.0.1:0")
+	}
+	os.Exit(m.Run())
+}
+
+// ---- suite ------------------------------------------------------------------
+
+type ExportTestSuite struct {
+	test.StatefunTestSuite
+}
+
+func TestExportTestSuite(t *testing.T) {
+	suite.Run(t, new(ExportTestSuite))
+}
+
+func (s *ExportTestSuite) setupRuntime() {
+	cfg := *statefun.NewFunctionTypeConfig().
+		SetAllowedRequestProviders(sfPlugins.AutoRequestSelect).
+		SetMaxIdHandlers(-1)
+
+	// Graph CRUD — needed by LLAPIPrintGraph for vertex.read and link.read
+	s.RegisterFunction("functions.graph.api.vertex.create", crud.LLAPIVertexCreate, cfg)
+	s.RegisterFunction("functions.graph.api.vertex.read", crud.LLAPIVertexRead, cfg)
+	s.RegisterFunction("functions.graph.api.link.create", crud.LLAPILinkCreate, cfg)
+	s.RegisterFunction("functions.graph.api.link.read", crud.LLAPILinkRead, cfg)
+
+	// Debug export: all export operations go through one function type
+	debugCfg := *statefun.NewFunctionTypeConfig().
+		SetAllowedRequestProviders(sfPlugins.AutoRequestSelect).
+		SetMsgAckWaitMs(MAX_ACK_WAIT_MS)
+	s.RegisterFunction("functions.graph.api.object.debug.print.graph", LLAPIPrintGraph, debugCfg)
+
+	s.NoError(s.StartRuntime())
+}
+
+// buildGraph creates root → child1, root → child2.
+func (s *ExportTestSuite) buildGraph() {
+	create := func(id string) {
+		p := easyjson.NewJSONObject()
+		result, err := s.Request(sfPlugins.AutoRequestSelect, "functions.graph.api.vertex.create", id, &p, nil)
+		s.NoError(err)
+		s.Equal("ok", result.GetByPath("status").AsStringDefault(""))
+	}
+
+	link := func(from, to, name, tp string) {
+		p := easyjson.NewJSONObject()
+		p.SetByPath("to", easyjson.NewJSON(s.SetThisDomainPreffix(to)))
+		p.SetByPath("name", easyjson.NewJSON(name))
+		p.SetByPath("type", easyjson.NewJSON(tp))
+		result, err := s.Request(sfPlugins.AutoRequestSelect, "functions.graph.api.link.create", from, &p, nil)
+		s.NoError(err)
+		s.Equal("ok", result.GetByPath("status").AsStringDefault(""))
+	}
+
+	create("root")
+	create("child1")
+	create("child2")
+	link("root", "child1", "c1", "contains")
+	link("root", "child2", "c2", "contains")
+}
+
+// printGraph requests a full graph export and returns the raw result JSON.
+func (s *ExportTestSuite) printGraph(id, format, delivery string) *easyjson.JSON {
+	p := easyjson.NewJSONObject()
+	p.SetByPath("format", easyjson.NewJSON(format))
+	p.SetByPath("delivery", easyjson.NewJSON(delivery))
+
+	result, err := s.Request(sfPlugins.AutoRequestSelect,
+		"functions.graph.api.object.debug.print.graph", id, &p, nil)
+	s.NoError(err)
+	return result
+}
+
+// assembleChunks fetches all chunks for a session and returns the assembled string.
+func (s *ExportTestSuite) assembleChunks(sessionID, vertexID string, totalChunks int) string {
+	var buf strings.Builder
+	for i := 0; i < totalChunks; i++ {
+		p := easyjson.NewJSONObject()
+		p.SetByPath("export_action", easyjson.NewJSON("get_chunk"))
+		p.SetByPath("session_id", easyjson.NewJSON(sessionID))
+		p.SetByPath("chunk_index", easyjson.NewJSON(i))
+
+		result, err := s.Request(sfPlugins.AutoRequestSelect,
+			"functions.graph.api.object.debug.print.graph", vertexID, &p, nil)
+		s.NoError(err)
+		s.Equal("ok", result.GetByPath("status").AsStringDefault(""), "chunk %d status", i)
+
+		buf.WriteString(result.GetByPath("data.data").AsStringDefault(""))
+
+		isLast := result.GetByPath("data.last").AsBoolDefault(false)
+		if i == totalChunks-1 {
+			s.True(isLast, "last chunk must set last=true")
+		} else {
+			s.False(isLast, "chunk %d should not be last", i)
+		}
+	}
+	return buf.String()
+}
+
+// ---- tests ------------------------------------------------------------------
+
+// Test_ChunkedExport_AssemblesCorrectly verifies that chunked assembly produces
+// a complete graph export matching total_bytes and containing expected content.
+func (s *ExportTestSuite) Test_ChunkedExport_AssemblesCorrectly() {
+	s.setupRuntime()
+	s.buildGraph()
+
+	chunkedResult := s.printGraph("root", "dot", "chunks")
+	s.Equal("ok", chunkedResult.GetByPath("status").AsStringDefault(""))
+	s.Equal("chunks", chunkedResult.GetByPath("data.delivery").AsStringDefault(""))
+
+	sessionID := chunkedResult.GetByPath("data.session_id").AsStringDefault("")
+	vertexID := chunkedResult.GetByPath("data.vertex_id").AsStringDefault("")
+	totalChunks := int(chunkedResult.GetByPath("data.total_chunks").AsNumericDefault(0))
+	totalBytes := int(chunkedResult.GetByPath("data.total_bytes").AsNumericDefault(0))
+	s.NotEmpty(sessionID)
+	s.NotEmpty(vertexID)
+	s.Greater(totalChunks, 0)
+	s.Greater(totalBytes, 0)
+
+	assembled := s.assembleChunks(sessionID, vertexID, totalChunks)
+
+	// Assembled length must match advertised total_bytes
+	s.Equal(totalBytes, len(assembled))
+
+	// Basic structural checks on DOT output
+	s.Contains(assembled, "digraph")
+	s.Contains(assembled, "hub/root")
+	s.Contains(assembled, "hub/child1")
+	s.Contains(assembled, "hub/child2")
+	s.Contains(assembled, "c1")
+	s.Contains(assembled, "c2")
+}
+
+// Test_ChunkedExport_FinishSession_ClearsSession verifies that FinishSession
+// releases the in-memory session so subsequent chunk reads fail.
+func (s *ExportTestSuite) Test_ChunkedExport_FinishSession_ClearsSession() {
+	s.setupRuntime()
+	s.buildGraph()
+
+	chunkedResult := s.printGraph("root", "dot", "chunks")
+	s.Equal("ok", chunkedResult.GetByPath("status").AsStringDefault(""))
+
+	sessionID := chunkedResult.GetByPath("data.session_id").AsStringDefault("")
+	vertexID := chunkedResult.GetByPath("data.vertex_id").AsStringDefault("")
+	s.NotEmpty(sessionID)
+
+	// Finish session explicitly
+	fp := easyjson.NewJSONObject()
+	fp.SetByPath("export_action", easyjson.NewJSON("finish_session"))
+	fp.SetByPath("session_id", easyjson.NewJSON(sessionID))
+	finishResult, err := s.Request(sfPlugins.AutoRequestSelect,
+		"functions.graph.api.object.debug.print.graph", vertexID, &fp, nil)
+	s.NoError(err)
+	s.Equal("ok", finishResult.GetByPath("status").AsStringDefault(""))
+
+	// Session must be gone — get_chunk should now fail
+	cp := easyjson.NewJSONObject()
+	cp.SetByPath("export_action", easyjson.NewJSON("get_chunk"))
+	cp.SetByPath("session_id", easyjson.NewJSON(sessionID))
+	cp.SetByPath("chunk_index", easyjson.NewJSON(0))
+	chunkResult, err := s.Request(sfPlugins.AutoRequestSelect,
+		"functions.graph.api.object.debug.print.graph", vertexID, &cp, nil)
+	s.NoError(err)
+	s.NotEqual("ok", chunkResult.GetByPath("status").AsStringDefault("ok"),
+		"get_chunk after finish_session should not return ok")
+}
+
+// Test_ChunkedExport_ChunksAreIdempotent verifies that reading the same chunk
+// index twice before FinishSession returns identical data.
+func (s *ExportTestSuite) Test_ChunkedExport_ChunksAreIdempotent() {
+	s.setupRuntime()
+	s.buildGraph()
+
+	result := s.printGraph("root", "dot", "chunks")
+	s.Equal("ok", result.GetByPath("status").AsStringDefault(""))
+
+	sessionID := result.GetByPath("data.session_id").AsStringDefault("")
+	vertexID := result.GetByPath("data.vertex_id").AsStringDefault("")
+
+	cp := easyjson.NewJSONObject()
+	cp.SetByPath("export_action", easyjson.NewJSON("get_chunk"))
+	cp.SetByPath("session_id", easyjson.NewJSON(sessionID))
+	cp.SetByPath("chunk_index", easyjson.NewJSON(0))
+
+	r1, _ := s.Request(sfPlugins.AutoRequestSelect,
+		"functions.graph.api.object.debug.print.graph", vertexID, &cp, nil)
+	r2, _ := s.Request(sfPlugins.AutoRequestSelect,
+		"functions.graph.api.object.debug.print.graph", vertexID, &cp, nil)
+
+	s.Equal(
+		r1.GetByPath("data.data").AsStringDefault(""),
+		r2.GetByPath("data.data").AsStringDefault(""),
+	)
+}
+
+// Test_InlineDelivery_ReturnsFileField checks that a plain inline export still
+// works (backward compatibility).
+func (s *ExportTestSuite) Test_InlineDelivery_ReturnsFileField() {
+	s.setupRuntime()
+	s.buildGraph()
+
+	result := s.printGraph("root", "dot", "inline")
+	s.Equal("ok", result.GetByPath("status").AsStringDefault(""))
+	s.Equal("inline", result.GetByPath("data.delivery").AsStringDefault(""))
+	s.NotEmpty(result.GetByPath("data.file").AsStringDefault(""))
+	// chunked fields must be absent
+	s.Empty(result.GetByPath("data.session_id").AsStringDefault(""))
+}
+
+// Test_UnknownExportAction verifies that an unrecognised export_action returns failed
+// instead of silently running a full graph export.
+func (s *ExportTestSuite) Test_UnknownExportAction() {
+	s.setupRuntime()
+
+	p := easyjson.NewJSONObject()
+	p.SetByPath("export_action", easyjson.NewJSON("get-chunk")) // typo: dash instead of underscore
+
+	result, err := s.Request(sfPlugins.AutoRequestSelect,
+		"functions.graph.api.object.debug.print.graph", "any-vertex", &p, nil)
+	s.NoError(err)
+	s.NotEqual("ok", result.GetByPath("status").AsStringDefault("ok"),
+		"unknown export_action must not silently run a graph export")
+}
+
+// Test_GetChunk_MissingSessionID verifies that an absent session_id returns a failed status.
+func (s *ExportTestSuite) Test_GetChunk_MissingSessionID() {
+	s.setupRuntime()
+
+	p := easyjson.NewJSONObject()
+	p.SetByPath("export_action", easyjson.NewJSON("get_chunk"))
+	p.SetByPath("chunk_index", easyjson.NewJSON(0)) // no session_id
+
+	result, err := s.Request(sfPlugins.AutoRequestSelect,
+		"functions.graph.api.object.debug.print.graph", "any-vertex", &p, nil)
+	s.NoError(err)
+	s.NotEqual("ok", result.GetByPath("status").AsStringDefault("ok"))
+}
+
+// Test_GetChunk_MissingChunkIndex verifies that an absent chunk_index returns a failed status.
+func (s *ExportTestSuite) Test_GetChunk_MissingChunkIndex() {
+	s.setupRuntime()
+
+	p := easyjson.NewJSONObject()
+	p.SetByPath("export_action", easyjson.NewJSON("get_chunk"))
+	p.SetByPath("session_id", easyjson.NewJSON("some-session")) // no chunk_index
+
+	result, err := s.Request(sfPlugins.AutoRequestSelect,
+		"functions.graph.api.object.debug.print.graph", "any-vertex", &p, nil)
+	s.NoError(err)
+	s.NotEqual("ok", result.GetByPath("status").AsStringDefault("ok"))
+}
+
+// Test_AutoDelivery_SmallGraph_UsesInline verifies that delivery:"auto" selects
+// inline for a graph that fits below the 1 MB threshold.
+func (s *ExportTestSuite) Test_AutoDelivery_SmallGraph_UsesInline() {
+	s.setupRuntime()
+	s.buildGraph()
+
+	p := easyjson.NewJSONObject()
+	p.SetByPath("format", easyjson.NewJSON("dot"))
+	p.SetByPath("delivery", easyjson.NewJSON("auto"))
+
+	result, err := s.Request(sfPlugins.AutoRequestSelect,
+		"functions.graph.api.object.debug.print.graph", "root", &p, nil)
+	s.NoError(err)
+	s.Equal("ok", result.GetByPath("status").AsStringDefault(""))
+	s.Equal("inline", result.GetByPath("data.delivery").AsStringDefault(""),
+		"small graph with delivery:auto must choose inline")
+	s.NotEmpty(result.GetByPath("data.file").AsStringDefault(""))
+	s.Empty(result.GetByPath("data.session_id").AsStringDefault(""))
+}
+
+// Test_ChunkedExport_GraphML verifies that graphml format works end-to-end
+// with chunked delivery.
+func (s *ExportTestSuite) Test_ChunkedExport_GraphML() {
+	s.setupRuntime()
+	s.buildGraph()
+
+	result := s.printGraph("root", "graphml", "chunks")
+	s.Equal("ok", result.GetByPath("status").AsStringDefault(""))
+	s.Equal("chunks", result.GetByPath("data.delivery").AsStringDefault(""))
+
+	sessionID := result.GetByPath("data.session_id").AsStringDefault("")
+	vertexID := result.GetByPath("data.vertex_id").AsStringDefault("")
+	totalChunks := int(result.GetByPath("data.total_chunks").AsNumericDefault(0))
+	totalBytes := int(result.GetByPath("data.total_bytes").AsNumericDefault(0))
+	s.NotEmpty(sessionID)
+	s.Greater(totalChunks, 0)
+
+	assembled := s.assembleChunks(sessionID, vertexID, totalChunks)
+
+	s.Equal(totalBytes, len(assembled))
+	s.Contains(assembled, "<graphml")
+	s.Contains(assembled, "hub/root")
+	s.Contains(assembled, "hub/child1")
+	s.Contains(assembled, "hub/child2")
+}
+
+// Test_AutoDelivery_LargeGraph_UsesChunks verifies that delivery:"auto" switches
+// to chunked mode when the export exceeds exportAutoThreshold.
+// The threshold is temporarily lowered to 1 byte to avoid building a real 1 MB graph.
+func (s *ExportTestSuite) Test_AutoDelivery_LargeGraph_UsesChunks() {
+	old := exportAutoThreshold
+	exportAutoThreshold = 1 // any non-empty export will exceed this
+	defer func() { exportAutoThreshold = old }()
+
+	s.setupRuntime()
+	s.buildGraph()
+
+	p := easyjson.NewJSONObject()
+	p.SetByPath("format", easyjson.NewJSON("dot"))
+	p.SetByPath("delivery", easyjson.NewJSON("auto"))
+
+	result, err := s.Request(sfPlugins.AutoRequestSelect,
+		"functions.graph.api.object.debug.print.graph", "root", &p, nil)
+	s.NoError(err)
+	s.Equal("ok", result.GetByPath("status").AsStringDefault(""))
+	s.Equal("chunks", result.GetByPath("data.delivery").AsStringDefault(""),
+		"export exceeding threshold must choose chunks")
+
+	// Verify assembly works correctly in auto→chunks path
+	sessionID := result.GetByPath("data.session_id").AsStringDefault("")
+	vertexID := result.GetByPath("data.vertex_id").AsStringDefault("")
+	totalChunks := int(result.GetByPath("data.total_chunks").AsNumericDefault(0))
+	totalBytes := int(result.GetByPath("data.total_bytes").AsNumericDefault(0))
+	s.Greater(totalChunks, 0)
+
+	assembled := s.assembleChunks(sessionID, vertexID, totalChunks)
+	s.Equal(totalBytes, len(assembled))
+	s.Contains(assembled, "digraph")
+}

--- a/embedded/graph/debug/graph.go
+++ b/embedded/graph/debug/graph.go
@@ -19,6 +19,11 @@ import (
 	lg "github.com/foliagecp/sdk/statefun/logger"
 )
 
+// exportAutoThreshold is the file size above which delivery:"auto" switches to
+// chunked mode. Declared as a variable so tests can lower it without building
+// a multi-megabyte graph.
+var exportAutoThreshold = 1 << 20 // 1 MB
+
 type gNode struct {
 	id    string
 	depth int
@@ -39,21 +44,50 @@ type exportConfig struct {
 }
 
 /*
-Print Graph from certain id using Graphviz
+LLAPIPrintGraph handles all graph export operations for a single vertex, dispatched
+by the optional export_action field:
 
-Algorithm: Sync BFS
+  - (absent)         — BFS graph traversal + export (default)
+  - "get_chunk"      — fetch one chunk of a previously started chunked export
+  - "finish_session" — release an in-memory export session
 
-	Payload: {
-		"depth": uint // optional, default: -1
-		"format": string // "dot" | "graphml" - optional, default: "dot"
-		"json2xml": bool // whether to export bodies as json or xml (graphml only) - optional, default false
-		"exclude": { // Fields to exclude during export, optional
-			"vertex": ["__meta", "fieldX.fieldY" ...] // optional
-			"edge": ["field1", ...] // optional
-		}
+All three actions are intentionally handled by the same function type so that
+the statefun single-instance lock guarantees they execute on the same process,
+where the in-memory ExportSessionStore lives.
+
+BFS payload:
+
+	{
+	    "depth":    int    // optional, default: -1 (unlimited)
+	    "format":   string // "dot" | "graphml", default: "dot"
+	    "delivery": string // "inline" | "auto" | "chunks", default: "inline"
+	    "json2xml": bool   // graphml only, default: false
+	    "exclude":  { "vertex": [...], "edge": [...] }  // optional
 	}
+
+get_chunk payload:
+
+	{ "export_action": "get_chunk", "session_id": "...", "chunk_index": N }
+
+finish_session payload:
+
+	{ "export_action": "finish_session", "session_id": "..." }
 */
 func LLAPIPrintGraph(executor sfPlugins.StatefunExecutor, ctx *sfPlugins.StatefunContextProcessor) {
+	switch action := ctx.Payload.GetByPath("export_action").AsStringDefault(""); action {
+	case "":
+		exportPrintGraph(ctx)
+	case "get_chunk":
+		exportGetChunk(ctx)
+	case "finish_session":
+		exportFinishSession(ctx)
+	default:
+		om := sfMediators.NewOpMediator(ctx)
+		om.AggregateOpMsg(sfMediators.OpMsgFailed(fmt.Sprintf("unknown export_action %q", action))).Reply()
+	}
+}
+
+func exportPrintGraph(ctx *sfPlugins.StatefunContextProcessor) {
 	self := ctx.Self
 	payload := ctx.Payload
 
@@ -69,9 +103,7 @@ func LLAPIPrintGraph(executor sfPlugins.StatefunExecutor, ctx *sfPlugins.Statefu
 
 	nodes := map[string]*easyjson.JSON{}
 	uniqueEdges := map[string]struct{}{}
-	queue := []gNode{}
-	queue = append(queue, gNode{self.ID, 0})
-
+	queue := []gNode{{self.ID, 0}}
 	edges := []gEdge{}
 
 	for len(queue) > 0 {
@@ -105,9 +137,8 @@ func LLAPIPrintGraph(executor sfPlugins.StatefunExecutor, ctx *sfPlugins.Statefu
 
 	om := sfMediators.NewOpMediator(ctx)
 
-	var fileData string
-
 	format := payload.GetByPath("format").AsStringDefault("dot")
+	var fileData string
 	switch format {
 	case "graphml":
 		fileData = createGraphML(ctx.Self.ID, ctx.Domain, nodes, edges, conf, payload.GetByPath("json2xml").AsBoolDefault(false))
@@ -118,9 +149,64 @@ func LLAPIPrintGraph(executor sfPlugins.StatefunExecutor, ctx *sfPlugins.Statefu
 		return
 	}
 
+	requestedDelivery := payload.GetByPath("delivery").AsStringDefault("inline")
+	useChunked := requestedDelivery == "chunks" ||
+		(requestedDelivery == "auto" && len(fileData) > exportAutoThreshold)
+
+	if useChunked {
+		sessionID, totalChunks, chunkSz := defaultStore.Put(fileData)
+		reply := easyjson.NewJSONObject()
+		reply.SetByPath("format", easyjson.NewJSON(format))
+		reply.SetByPath("delivery", easyjson.NewJSON("chunks"))
+		reply.SetByPath("session_id", easyjson.NewJSON(sessionID))
+		reply.SetByPath("vertex_id", easyjson.NewJSON(ctx.Self.ID))
+		reply.SetByPath("total_chunks", easyjson.NewJSON(totalChunks))
+		reply.SetByPath("total_bytes", easyjson.NewJSON(int64(len(fileData))))
+		reply.SetByPath("chunk_size", easyjson.NewJSON(chunkSz))
+		om.AggregateOpMsg(sfMediators.OpMsgOk(reply)).Reply()
+		return
+	}
+
 	reply := easyjson.NewJSONObjectWithKeyValue("file", easyjson.NewJSON(fileData))
 	reply.SetByPath("format", easyjson.NewJSON(format))
+	reply.SetByPath("delivery", easyjson.NewJSON("inline"))
 	om.AggregateOpMsg(sfMediators.OpMsgOk(reply)).Reply()
+}
+
+func exportGetChunk(ctx *sfPlugins.StatefunContextProcessor) {
+	om := sfMediators.NewOpMediator(ctx)
+	payload := ctx.Payload
+
+	sessionID := payload.GetByPath("session_id").AsStringDefault("")
+	chunkIndex := int(payload.GetByPath("chunk_index").AsNumericDefault(-1))
+	if sessionID == "" || chunkIndex < 0 {
+		om.AggregateOpMsg(sfMediators.OpMsgFailed("session_id and chunk_index are required")).Reply()
+		return
+	}
+
+	data, last, err := defaultStore.GetChunk(sessionID, chunkIndex)
+	if err != nil {
+		lg.Logf(lg.WarnLevel, "get_chunk: vertex=%s session=%s index=%d: %v", ctx.Self.ID, sessionID, chunkIndex, err)
+		om.AggregateOpMsg(sfMediators.OpMsgFailed(err.Error())).Reply()
+		return
+	}
+
+	reply := easyjson.NewJSONObject()
+	reply.SetByPath("data", easyjson.NewJSON(data))
+	reply.SetByPath("chunk_index", easyjson.NewJSON(chunkIndex))
+	reply.SetByPath("last", easyjson.NewJSON(last))
+	om.AggregateOpMsg(sfMediators.OpMsgOk(reply)).Reply()
+}
+
+func exportFinishSession(ctx *sfPlugins.StatefunContextProcessor) {
+	om := sfMediators.NewOpMediator(ctx)
+	sessionID := ctx.Payload.GetByPath("session_id").AsStringDefault("")
+	if sessionID == "" {
+		om.AggregateOpMsg(sfMediators.OpMsgFailed("session_id is required")).Reply()
+		return
+	}
+	defaultStore.FinishSession(sessionID)
+	om.AggregateOpMsg(sfMediators.OpMsgOk(easyjson.NewJSONObject())).Reply()
 }
 
 func getVertexBodyAndOutLinks(ctx *sfPlugins.StatefunContextProcessor, id string) (*easyjson.JSON, []gEdge) {

--- a/embedded/graph/debug/session_store.go
+++ b/embedded/graph/debug/session_store.go
@@ -1,0 +1,127 @@
+// Foliage graph store debug package.
+// Provides debug stateful functions for the graph store
+package debug
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/foliagecp/sdk/statefun/system"
+	"github.com/google/uuid"
+)
+
+// maxChunkSize caps EXPORT_CHUNK_SIZE to leave headroom for JSON encoding
+// overhead on the wire. At 512 KB raw the worst-case JSON-escaped payload
+// is ~3 MB, well within the typical NATS max_payload of 8–64 MB.
+const maxChunkSize = 512 * 1024
+
+// chunkSize is the byte size of each export chunk.
+// 128 KB is conservative: JSON/XML escaping of body content can expand raw bytes
+// significantly (up to ×6 for all-control-character payloads), and the chunk
+// string is embedded in a JSON envelope on the wire, so the actual NATS message
+// can be larger than chunkSize.
+// Override with EXPORT_CHUNK_SIZE env var (bytes); clamped to [1, 512 KB].
+var chunkSize = func() int {
+	v := system.GetEnvMustProceed("EXPORT_CHUNK_SIZE", 128<<10)
+	if v <= 0 {
+		return 128 << 10
+	}
+	if v > maxChunkSize {
+		return maxChunkSize
+	}
+	return v
+}()
+
+const sessionTTL = 10 * time.Minute
+
+type exportSession struct {
+	data      string
+	chunkSize int
+	expiresAt time.Time
+}
+
+// ExportSessionStore holds large export payloads in memory while the client fetches them chunk by chunk.
+// Sessions are bound to this runtime process — restart or rebalance invalidates all sessions.
+type ExportSessionStore struct {
+	mu       sync.Mutex
+	sessions map[string]*exportSession
+}
+
+var defaultStore = func() *ExportSessionStore {
+	s := &ExportSessionStore{sessions: make(map[string]*exportSession)}
+	go s.cleanupLoop()
+	return s
+}()
+
+// Put stores the export data and returns the session ID, total chunk count, and chunk size.
+func (s *ExportSessionStore) Put(data string) (sessionID string, totalChunks int, cs int) {
+	sessionID = uuid.New().String()
+	cs = chunkSize
+	totalChunks = (len(data) + cs - 1) / cs
+	s.mu.Lock()
+	s.sessions[sessionID] = &exportSession{
+		data:      data,
+		chunkSize: cs,
+		expiresAt: time.Now().Add(sessionTTL),
+	}
+	s.mu.Unlock()
+	return sessionID, totalChunks, cs
+}
+
+// TotalChunks returns the number of chunks and the chunk size for a session.
+func (s *ExportSessionStore) TotalChunks(sessionID string) (total int, chunkSize int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		return 0, 0, fmt.Errorf("session %q not found", sessionID)
+	}
+	total = (len(sess.data) + sess.chunkSize - 1) / sess.chunkSize
+	return total, sess.chunkSize, nil
+}
+
+// GetChunk returns a data slice for the given chunk index.
+// Reading is idempotent — the session is not deleted. Retry of any chunk is possible until
+// FinishSession is called or the TTL expires.
+// Each successful read extends the session TTL to prevent expiry during slow transfers.
+func (s *ExportSessionStore) GetChunk(sessionID string, index int) (data string, last bool, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		return "", false, fmt.Errorf("session %q not found or expired (runtime restarted?)", sessionID)
+	}
+	start := index * sess.chunkSize
+	if start >= len(sess.data) {
+		return "", false, fmt.Errorf("chunk index %d out of range", index)
+	}
+	end := start + sess.chunkSize
+	if end > len(sess.data) {
+		end = len(sess.data)
+	}
+	sess.expiresAt = time.Now().Add(sessionTTL)
+	return sess.data[start:end], end == len(sess.data), nil
+}
+
+// FinishSession explicitly frees the session. The client calls this after successful assembly.
+func (s *ExportSessionStore) FinishSession(sessionID string) {
+	s.mu.Lock()
+	delete(s.sessions, sessionID)
+	s.mu.Unlock()
+}
+
+func (s *ExportSessionStore) cleanupLoop() {
+	ticker := time.NewTicker(2 * time.Minute)
+	defer ticker.Stop()
+	for range ticker.C {
+		now := time.Now()
+		s.mu.Lock()
+		for id, sess := range s.sessions {
+			if now.After(sess.expiresAt) {
+				delete(s.sessions, id)
+			}
+		}
+		s.mu.Unlock()
+	}
+}

--- a/embedded/graph/debug/session_store_test.go
+++ b/embedded/graph/debug/session_store_test.go
@@ -1,0 +1,265 @@
+package debug
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestStore() *ExportSessionStore {
+	return &ExportSessionStore{sessions: make(map[string]*exportSession)}
+}
+
+// mustPut stores data and returns just the session ID, discarding chunk metadata.
+func mustPut(s *ExportSessionStore, data string) string {
+	id, _, _ := s.Put(data)
+	return id
+}
+
+// expireSession backdates a session's TTL so the next cleanup pass removes it.
+func expireSession(s *ExportSessionStore, id string) {
+	s.mu.Lock()
+	if sess, ok := s.sessions[id]; ok {
+		sess.expiresAt = time.Now().Add(-time.Minute)
+	}
+	s.mu.Unlock()
+}
+
+// runCleanup executes one cleanup pass (same logic as cleanupLoop body).
+func runCleanup(s *ExportSessionStore) {
+	now := time.Now()
+	s.mu.Lock()
+	for id, sess := range s.sessions {
+		if now.After(sess.expiresAt) {
+			delete(s.sessions, id)
+		}
+	}
+	s.mu.Unlock()
+}
+
+// ---- Put ----------------------------------------------------------------
+
+func TestExportSessionStore_Put_ReturnsNonEmptyID(t *testing.T) {
+	s := newTestStore()
+	id := mustPut(s, "data")
+	assert.NotEmpty(t, id)
+}
+
+func TestExportSessionStore_Put_ReturnsUniqueIDs(t *testing.T) {
+	s := newTestStore()
+	ids := make(map[string]struct{}, 10)
+	for i := 0; i < 10; i++ {
+		id := mustPut(s, "x")
+		ids[id] = struct{}{}
+	}
+	assert.Len(t, ids, 10)
+}
+
+// ---- TotalChunks --------------------------------------------------------
+
+func TestExportSessionStore_TotalChunks_Sizes(t *testing.T) {
+	s := newTestStore()
+
+	cases := []struct {
+		name       string
+		dataLen    int
+		wantChunks int
+	}{
+		{"single byte", 1, 1},
+		{"exact one chunk", chunkSize, 1},
+		{"one byte over chunk", chunkSize + 1, 2},
+		{"exact two chunks", 2 * chunkSize, 2},
+		{"two chunks minus one", 2*chunkSize - 1, 2},
+		{"three chunks not aligned", 3*chunkSize - 7, 3},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id := mustPut(s, strings.Repeat("x", tc.dataLen))
+			total, cs, err := s.TotalChunks(id)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantChunks, total)
+			assert.Equal(t, chunkSize, cs)
+		})
+	}
+}
+
+func TestExportSessionStore_TotalChunks_UnknownSession(t *testing.T) {
+	s := newTestStore()
+	_, _, err := s.TotalChunks("no-such-id")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// ---- GetChunk -----------------------------------------------------------
+
+func TestExportSessionStore_GetChunk_AssemblesFullData(t *testing.T) {
+	s := newTestStore()
+
+	// 2.5 chunks worth of distinguishable data
+	data := strings.Repeat("a", chunkSize) +
+		strings.Repeat("b", chunkSize) +
+		strings.Repeat("c", chunkSize/2)
+
+	id := mustPut(s, data)
+	total, _, err := s.TotalChunks(id)
+	require.NoError(t, err)
+	require.Equal(t, 3, total)
+
+	var assembled strings.Builder
+	for i := 0; i < total; i++ {
+		chunk, last, err := s.GetChunk(id, i)
+		require.NoError(t, err, "chunk %d", i)
+		assembled.WriteString(chunk)
+
+		if i < total-1 {
+			assert.False(t, last, "chunk %d should not be last", i)
+		} else {
+			assert.True(t, last, "last chunk must set last=true")
+		}
+	}
+
+	assert.Equal(t, data, assembled.String())
+}
+
+func TestExportSessionStore_GetChunk_SingleChunk(t *testing.T) {
+	s := newTestStore()
+	id := mustPut(s, "hello world")
+
+	chunk, last, err := s.GetChunk(id, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", chunk)
+	assert.True(t, last)
+}
+
+func TestExportSessionStore_GetChunk_Idempotent(t *testing.T) {
+	s := newTestStore()
+	id := mustPut(s, strings.Repeat("z", chunkSize+1))
+
+	for i := 0; i < 5; i++ {
+		c0a, last0a, err := s.GetChunk(id, 0)
+		require.NoError(t, err)
+		c0b, last0b, _ := s.GetChunk(id, 0)
+		assert.Equal(t, c0a, c0b)
+		assert.Equal(t, last0a, last0b)
+	}
+}
+
+func TestExportSessionStore_GetChunk_OutOfRange(t *testing.T) {
+	s := newTestStore()
+	id := mustPut(s, "small")
+
+	_, _, err := s.GetChunk(id, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+}
+
+func TestExportSessionStore_GetChunk_UnknownSession(t *testing.T) {
+	s := newTestStore()
+	_, _, err := s.GetChunk("ghost", 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// ---- FinishSession ------------------------------------------------------
+
+func TestExportSessionStore_FinishSession_RemovesSession(t *testing.T) {
+	s := newTestStore()
+	id := mustPut(s, "data")
+
+	_, _, err := s.GetChunk(id, 0)
+	require.NoError(t, err)
+
+	s.FinishSession(id)
+
+	_, _, err = s.GetChunk(id, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestExportSessionStore_FinishSession_NoopOnMissing(t *testing.T) {
+	s := newTestStore()
+	assert.NotPanics(t, func() { s.FinishSession("ghost") })
+}
+
+// ---- TTL cleanup --------------------------------------------------------
+
+func TestExportSessionStore_Cleanup_RemovesExpiredSession(t *testing.T) {
+	s := newTestStore()
+	id := mustPut(s, "data")
+
+	expireSession(s, id)
+	runCleanup(s)
+
+	_, _, err := s.GetChunk(id, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestExportSessionStore_Cleanup_PreservesValidSession(t *testing.T) {
+	s := newTestStore()
+	expired := mustPut(s, "old")
+	valid := mustPut(s, "new")
+
+	expireSession(s, expired)
+	runCleanup(s)
+
+	_, _, err := s.GetChunk(expired, 0)
+	require.Error(t, err)
+
+	_, _, err = s.GetChunk(valid, 0)
+	require.NoError(t, err)
+}
+
+// ---- Concurrency --------------------------------------------------------
+
+func TestExportSessionStore_ConcurrentReads(t *testing.T) {
+	s := newTestStore()
+	data := strings.Repeat("x", chunkSize+1) // two chunks
+	id := mustPut(s, data)
+	total, _, err := s.TotalChunks(id)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	const workers = 20
+	results := make([]string, workers)
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			var b strings.Builder
+			for c := 0; c < total; c++ {
+				chunk, _, _ := s.GetChunk(id, c)
+				b.WriteString(chunk)
+			}
+			results[idx] = b.String()
+		}(i)
+	}
+
+	wg.Wait()
+	for i, got := range results {
+		assert.Equal(t, data, got, "worker %d got wrong data", i)
+	}
+}
+
+func TestExportSessionStore_ConcurrentPutFinish(t *testing.T) {
+	s := newTestStore()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			id := mustPut(s, "ephemeral")
+			_, _, err := s.GetChunk(id, 0)
+			assert.NoError(t, err)
+			s.FinishSession(id)
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Large graph exports can exceed the NATS max_payload limit when returned as a
single request-reply response. This adds chunked delivery for graph debug
exports using an in-memory export session store.

The print.graph handler now supports delivery modes for inline, auto, and
chunked responses. Chunk retrieval and session cleanup are routed through the
same function type via export_action so the in-memory session remains local to
the active statefun process.

Also adds tests for chunk assembly, idempotent chunk reads, finish_session
cleanup, auto delivery selection, GraphML chunked export, and invalid
export_action handling.